### PR TITLE
travis: g++-8 -> g++-9, clang-8 -> clang-10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,40 @@
 language: cpp
-dist: xenial
+dist: bionic
 sudo: false
 
 matrix:
   include:
-    - name: g++-8
+    - name: g++-9
       os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-8
+            - g++-9
       install:
         - pip install --user conan
       script:
-        - CXX=g++-8 CC=gcc-8 conan install . -pr conan_profiles/linux_gcc --build
-        - CXX=g++-8 cmake .
+        - CXX=g++-9 CC=gcc-9 conan install . -pr conan_profiles/linux_gcc --build
+        - CXX=g++-9 cmake .
         - cmake --build . -- -j$(nproc)
         - ctest --output-on-failure
 
-    - name: clang-8
+    - name: clang-10
       os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test  # for libstdc++
-            - llvm-toolchain-xenial-8
+            - llvm-toolchain-bionic-10
           packages:
-            - clang-8
-            - clang-tidy-8
-            - libstdc++-8-dev  # for <filesystem>
+            - clang-10
+            - clang-tidy-10
+            - libstdc++-10-dev  # for <filesystem>
       install:
         - pip install --user conan
       script:
-        - CXX=clang++-8 CC=clang-8 conan install .  -pr conan_profiles/linux_clang --build
-        - CXX=clang++-8 cmake .
+        - CXX=clang++-10 CC=clang-10 conan install .  -pr conan_profiles/linux_clang --build
+        - CXX=clang++-10 cmake .
         - cmake --build . -- -j$(nproc)
         - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test  # for libstdc++
             - llvm-toolchain-bionic-10
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - clang-10
             - clang-tidy-10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ list(FILTER ALL_HEADER_FILES EXCLUDE REGEX "#")
 set(ALL_INPUT_FILES ${ALL_SOURCE_FILES} ${ALL_HEADER_FILES})
 
 find_program(CLANG_FORMAT
-  NAMES clang-format clang-format-7)
+  NAMES clang-format clang-format-10)
 
 if(CLANG_FORMAT)
   add_custom_target(format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,7 @@ list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX "#")
 list(FILTER ALL_HEADER_FILES EXCLUDE REGEX "#")
 set(ALL_INPUT_FILES ${ALL_SOURCE_FILES} ${ALL_HEADER_FILES})
 
-find_program(CLANG_FORMAT
-  NAMES clang-format clang-format-10)
+find_program(CLANG_FORMAT NAMES clang-format-10)
 
 if(CLANG_FORMAT)
   add_custom_target(format

--- a/conan_profiles/linux_clang
+++ b/conan_profiles/linux_clang
@@ -4,7 +4,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=clang
-compiler.version=8
+compiler.version=10
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]

--- a/conan_profiles/linux_gcc
+++ b/conan_profiles/linux_gcc
@@ -4,7 +4,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=gcc
-compiler.version=8
+compiler.version=9
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ option(USE_CLANG_TIDY "Use clang-tidy if available" ON)
 # the compile time went from 16s to 48s.
 #
 if(USE_CLANG_TIDY)
-  find_program(CLANG_TIDY NAMES clang-tidy clang-tidy-10)
+  find_program(CLANG_TIDY NAMES clang-tidy-10)
 
   if(CLANG_TIDY)
     message(STATUS "Enabling clang-tidy: ${CLANG_TIDY}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ option(USE_CLANG_TIDY "Use clang-tidy if available" ON)
 # the compile time went from 16s to 48s.
 #
 if(USE_CLANG_TIDY)
-  find_program(CLANG_TIDY clang-tidy)
+  find_program(CLANG_TIDY NAMES clang-tidy clang-tidy-10)
 
   if(CLANG_TIDY)
     message(STATUS "Enabling clang-tidy: ${CLANG_TIDY}")
@@ -55,7 +55,7 @@ add_custom_target(doc COMMAND doxygen WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Note this needs to be compiled with afl-g++ or afl-clang++
 add_executable(zit_afl EXCLUDE_FROM_ALL main_afl.cpp)
-target_link_libraries(zit ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(zit ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
 if(NOT WIN32)
   target_link_libraries(zit pthread)
   if(SANITIZED_LIBCXX)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(zitest
   ../src/sha1.cpp
   ../src/messages.cpp
   ../src/piece.cpp)
-target_link_libraries(zitest gtest ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
+target_link_libraries(zitest gtest ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES} Threads::Threads)
 if(NOT WIN32)
   if(SANITIZED_LIBCXX)
     target_link_libraries(zitest c++fs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(zitest
   ../src/sha1.cpp
   ../src/messages.cpp
   ../src/piece.cpp)
-target_link_libraries(zitest gtest ${OPENSSL_CRYPTO_LIBRARY} Threads::Threads)
+target_link_libraries(zitest gtest ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
 if(NOT WIN32)
   if(SANITIZED_LIBCXX)
     target_link_libraries(zitest c++fs)


### PR DESCRIPTION
Will not try to support older compilers from now on so just replace travis with the newest.