### PR TITLE
Fix test net.chunkedTransfer (SNI)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -241,6 +241,13 @@ static std::tuple<std::string, std::string> httpsGet(const Url& url) {
   // Perform SSL handshake and verify the remote host's
   // certificate.
   sock.set_verify_mode(ssl::verify_peer);
+
+  // Without this some servers fail with "handshake: sslv3 alert handshake failure"
+  // These servers rely on SNI (Server Name Indication)
+  if(!SSL_set_tlsext_host_name(sock.native_handle(), url.host().c_str())) {
+    spdlog::get("console")->warn("Could not set host name for SNI");
+  }
+
   sock.set_verify_callback(
       [&url](bool preverified, asio::ssl::verify_context& ctx_) {
         if (!preverified) {


### PR DESCRIPTION
This test now need SNI, apparently it did not
earlier so something changed server side.