### PR TITLE
Use std::span to avoid copy

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -219,14 +219,11 @@ size_t Message::parse(PeerConnection& connection) {
           peer.set_choking(false);
           return len + 4;
         case peer_wire_id::PIECE: {
-          auto index = big_endian(m_msg, 5);
-          auto offset = big_endian(m_msg, 9);
-          // FIXME: Optimization:
-          //        Could pass the range instead of copying the data
-          auto start = m_msg.begin() + 13;
-          auto end = start + (len - 9);
-          auto data = bytes(start, end);
-          peer.set_block(index, offset, data);
+          const auto index = big_endian(m_msg, 5);
+          const auto offset = big_endian(m_msg, 9);
+          const auto start = m_msg.begin() + 13;
+          const auto end = start + (len - 9);
+          peer.set_block(index, offset, {start, end});
         }
           return len + 4;
         case peer_wire_id::INTERESTED:

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -242,9 +242,9 @@ static std::tuple<std::string, std::string> httpsGet(const Url& url) {
   // certificate.
   sock.set_verify_mode(ssl::verify_peer);
 
-  // Without this some servers fail with "handshake: sslv3 alert handshake failure"
-  // These servers rely on SNI (Server Name Indication)
-  if(!SSL_set_tlsext_host_name(sock.native_handle(), url.host().c_str())) {
+  // Without this some servers fail with "handshake: sslv3 alert handshake
+  // failure" These servers rely on SNI (Server Name Indication)
+  if (!SSL_set_tlsext_host_name(sock.native_handle(), url.host().c_str())) {
     spdlog::get("console")->warn("Could not set host name for SNI");
   }
 

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -275,7 +275,7 @@ void Peer::set_am_interested(bool am_interested) {
     // Send NOT_INTERESTED
     m_logger->debug("Sending NOT_INTERESTED");
     string interested_msg = {0, 0, 0, 1,
-                         static_cast<pwid_t>(peer_wire_id::NOT_INTERESTED)};
+                             static_cast<pwid_t>(peer_wire_id::NOT_INTERESTED)};
     stringstream hs;
     hs.write(interested_msg.c_str(),
              numeric_cast<std::streamsize>(interested_msg.length()));
@@ -377,7 +377,7 @@ void Peer::have(uint32_t id) {
   m_remote_pieces[id] = true;
 }
 
-void Peer::set_block(uint32_t piece_id, uint32_t offset, const bytes& data) {
+void Peer::set_block(uint32_t piece_id, uint32_t offset, bytes_span data) {
   if (m_torrent.set_block(piece_id, offset, data)) {
     request_next_block(1);
   }

--- a/src/peer.hpp
+++ b/src/peer.hpp
@@ -178,7 +178,7 @@ class Peer {
   /**
    * Store a retrieved a block ( part of a piece )
    */
-  void set_block(uint32_t piece_id, uint32_t offset, const bytes& data);
+  void set_block(uint32_t piece_id, uint32_t offset, bytes_span data);
 
   /**
    * Stop this connection.

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -38,7 +38,7 @@ bytes Piece::data() const {
   return m_data;
 }
 
-bool Piece::set_block(uint32_t offset, const bytes& data) {
+bool Piece::set_block(uint32_t offset, bytes_span data) {
   if (offset % m_block_size != 0) {
     throw runtime_error("Invalid block offset: " + to_string(offset));
   }

--- a/src/piece.hpp
+++ b/src/piece.hpp
@@ -50,7 +50,7 @@ class Piece {
    * Store incoming data
    * @return true if this was the last remaining block for this piece
    */
-  bool set_block(uint32_t offset, const bytes& data);
+  bool set_block(uint32_t offset, bytes_span data);
 
   /**
    * Return a specific block. Can return empty vector if

--- a/src/sha1.cpp
+++ b/src/sha1.cpp
@@ -96,7 +96,8 @@ Sha1 Sha1::fromBuffer(const T& buffer, typename T::size_type offset) {
     throw invalid_argument("Buffer too small for extracting sha1");
   }
   Sha1 ret;
-  copy_n(reinterpret_cast<const char*>(&buffer[offset]), SHA_LENGTH, ret.data());
+  copy_n(reinterpret_cast<const char*>(&buffer[offset]), SHA_LENGTH,
+         ret.data());
   return ret;
 }
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -222,8 +222,8 @@ void Torrent::verify_existing_file() {
             data.resize(data.size() - numeric_cast<size_t>(remaining));
             const auto fsha1 = Sha1::calculateData(data);
             if (sha1 == fsha1) {
-              // Lock when updating num_pieces, inserting into std::map is likely
-              // not thread safe.
+              // Lock when updating num_pieces, inserting into std::map is
+              // likely not thread safe.
               std::lock_guard<std::mutex> lock(mutex);
               m_client_pieces[id] = true;
               m_active_pieces.emplace(id,
@@ -431,7 +431,7 @@ void Torrent::retry_pieces() {
 
 // TODO: Yes, should group these in one type
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-bool Torrent::set_block(uint32_t piece_id, uint32_t offset, const bytes& data) {
+bool Torrent::set_block(uint32_t piece_id, uint32_t offset, bytes_span data) {
   std::lock_guard<std::mutex> lock(m_mutex);
   // Look up relevant piece object among active pieces
   if (m_active_pieces.find(piece_id) != m_active_pieces.end()) {

--- a/src/torrent.hpp
+++ b/src/torrent.hpp
@@ -227,7 +227,7 @@ class Torrent {
    *
    * @return true if the block was stored
    */
-  bool set_block(uint32_t piece_id, uint32_t offset, const bytes& data);
+  bool set_block(uint32_t piece_id, uint32_t offset, bytes_span data);
 
   /**
    * Create or return active piece for specific id.

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>  // uint8_t
 #include <iostream>
 #include <limits>
+#include <span>
 #include <stdexcept>  // out_of_range
 #include <vector>
 
@@ -17,6 +18,7 @@ namespace zit {
 
 // Type aliases
 using bytes = std::vector<std::byte>;
+using bytes_span = const std::span<const std::byte>;
 
 // numeric_cast ( Copied from https://codereview.stackexchange.com/a/26496/39248
 // ) by user Matt Whitlock - functions renamed.


### PR DESCRIPTION
There was one unnecessary copy of bytes, by using a span instead we only copy in
the end when needed.