### PR TITLE
Use strong types

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@
 # -altera-struct-pack-align (too specific performance issue)
 # -readability-function-cognitive-complexity (no hard limit on this)
 # -hicpp-named-parameter (fine to leave it out when unused)
-# -bugprone-easily-swappable-parameters(TODO: Fix this with strong types)
 # -cppcoreguidelines-special-member-functions (TODO: Fix this)
 # -hicpp-special-member-functions(same as cppcoreguidelines-special-member-functions)
 
@@ -52,7 +51,6 @@ Checks:          '*,
                  -altera-struct-pack-align,
                  -readability-function-cognitive-complexity,
                  -hicpp-named-parameter,
-                 -bugprone-easily-swappable-parameters,
                  -cppcoreguidelines-special-member-functions,
                  -hicpp-special-member-functions,
                  '

--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -25,11 +25,10 @@ namespace zit {
 // we use std::bind, std::shared_ptr, etc... which
 // differs slightly from the boost examples.
 
-// TODO: Use strong types
 PeerConnection::PeerConnection(Peer& peer,
                                asio::io_service& io_service,
-                               unsigned short listening_port,
-                               unsigned short connection_port)
+                               ListeningPort listening_port,
+                               ConnectionPort connection_port)
     : peer_(peer),
       resolver_(io_service),
       acceptor_(io_service, tcp::v4()),
@@ -42,11 +41,11 @@ PeerConnection::PeerConnection(Peer& peer,
 }
 
 void PeerConnection::listen() {
-  m_logger->info("{} port={}", PRETTY_FUNCTION, m_listening_port);
+  m_logger->info("{} port={}", PRETTY_FUNCTION, m_listening_port.get());
   // if (!acceptor_.is_open()) {
   asio::socket_base::reuse_address option(true);
   acceptor_.set_option(option);
-  acceptor_.bind(tcp::endpoint(tcp::v4(), m_listening_port));
+  acceptor_.bind(tcp::endpoint(tcp::v4(), m_listening_port.get()));
   //}
   acceptor_.listen();
   acceptor_.async_accept(
@@ -115,7 +114,7 @@ void PeerConnection::handle_resolve(const asio::error_code& err,
     endpoint_ = endpoint_iterator;
     asio::socket_base::reuse_address option(true);
     socket_.set_option(option);
-    socket_.bind(tcp::endpoint(tcp::v4(), m_connection_port));
+    socket_.bind(tcp::endpoint(tcp::v4(), m_connection_port.get()));
     socket_.async_connect(endpoint, [this, it = ++endpoint_iterator](
                                         auto&& ec) { handle_connect(ec, it); });
   } else {

--- a/src/peer.hpp
+++ b/src/peer.hpp
@@ -29,8 +29,8 @@ class PeerConnection {
  public:
   PeerConnection(Peer& peer,
                  asio::io_service& io_service,
-                 unsigned short listening_port,
-                 unsigned short connection_port);
+                 ListeningPort listening_port,
+                 ConnectionPort connection_port);
 
   void write(const std::optional<Url>& url, const bytes& msg);
   void write(const std::optional<Url>& url, const std::string& msg);
@@ -71,8 +71,8 @@ class PeerConnection {
   std::deque<std::string> m_send_queue{};
   bool m_connected = false;
   bool m_sending = false;
-  unsigned short m_listening_port;
-  unsigned short m_connection_port;
+  ListeningPort m_listening_port;
+  ConnectionPort m_connection_port;
   std::shared_ptr<spdlog::logger> m_logger;
 };
 

--- a/src/piece.hpp
+++ b/src/piece.hpp
@@ -12,16 +12,19 @@ namespace zit {
 
 class Torrent;
 
+using PieceId = StrongType<uint32_t, struct IdTag>;
+using PieceSize = StrongType<uint32_t, struct SizeTag>;
+
 /**
  * Represents one torrent piece and its current state.
  */
 class Piece {
  public:
-  explicit Piece(uint32_t id, uint32_t piece_size)
-      : m_piece_size(piece_size),
+  explicit Piece(PieceId id, PieceSize piece_size)
+      : m_piece_size(piece_size.get()),
         m_blocks_requested(block_count()),
         m_blocks_done(block_count()),
-        m_id(id),
+        m_id(id.get()),
         m_logger(spdlog::get("console")) {
     m_data.resize(m_piece_size);
   }

--- a/src/strong_type.hpp
+++ b/src/strong_type.hpp
@@ -1,0 +1,26 @@
+// -*- mode:c++; c-basic-offset : 2; -*-
+#pragma once
+
+#include <memory>
+
+/**
+ * Simple implementation of a StrongType, used like so:
+ *
+ * @code {.cpp}
+ * using Port = StrongType<unsigned, struct PortTag>;
+ * Port p{12};
+ * std::cout << p.get() << "\n";
+ * @endcode
+ *
+ */
+template <typename T, typename Tag>
+class StrongType {
+ public:
+  explicit StrongType(T t) : m_val(std::move(t)) {}
+
+  [[nodiscard]] constexpr T& get() noexcept { return m_val; }
+  [[nodiscard]] constexpr const T& get() const noexcept { return m_val; }
+
+ private:
+  T m_val;
+};

--- a/src/torrent.hpp
+++ b/src/torrent.hpp
@@ -10,6 +10,7 @@
 
 // Needed for spdlog to handle operator<<
 #include "spdlog/fmt/ostr.h"
+#include "types.hpp"
 
 namespace zit {
 
@@ -304,8 +305,8 @@ class Torrent {
   PieceCallback m_piece_callback{};
   DisconnectCallback m_disconnect_callback{};
   // FIXME: Configurable ports
-  unsigned short m_listening_port = 20001;
-  unsigned short m_connection_port = 20000;
+  ListeningPort m_listening_port{20001};
+  ConnectionPort m_connection_port{20000};
   std::vector<std::shared_ptr<Peer>> m_peers{};
 
   // Piece housekeeping

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -1,16 +1,15 @@
 // -*- mode:c++; c-basic-offset : 2; -*-
 #pragma once
 
+#include <spdlog/fmt/fmt.h>
+#include <asio.hpp>
 #include <cstdint>  // uint8_t
 #include <iostream>
 #include <limits>
 #include <span>
 #include <stdexcept>  // out_of_range
 #include <vector>
-
-#include <asio.hpp>
-
-#include <spdlog/fmt/fmt.h>
+#include "strong_type.hpp"
 
 using asio::detail::socket_ops::host_to_network_long;
 
@@ -19,6 +18,10 @@ namespace zit {
 // Type aliases
 using bytes = std::vector<std::byte>;
 using bytes_span = const std::span<const std::byte>;
+
+// String types
+using ListeningPort = StrongType<unsigned short, struct ListeningPortTag>;
+using ConnectionPort = StrongType<unsigned short, struct ConnectionPortTag>;
 
 // numeric_cast ( Copied from https://codereview.stackexchange.com/a/26496/39248
 // ) by user Matt Whitlock - functions renamed.


### PR DESCRIPTION
Avoid easily swappable parameter and allow for more readable code by using
strong types. Currently a very simple implementation is used.