### PR TITLE
Generate peer_id

### DIFF
--- a/src/peer.cpp
+++ b/src/peer.cpp
@@ -441,7 +441,7 @@ void Peer::handshake() {
   hs << static_cast<char>(19) << "BitTorrent protocol";
   hs.write(RESERVED.c_str(), numeric_cast<std::streamsize>(RESERVED.length()));
   hs << m_torrent.info_hash().str()
-     << "abcdefghijklmnopqrst";  // FIXME: Use proper peer-id
+     << m_torrent.peer_id();
 
   init_io_service();
   m_connection->write(m_url, hs.str());

--- a/src/torrent.hpp
+++ b/src/torrent.hpp
@@ -261,6 +261,11 @@ class Torrent {
   [[nodiscard]] auto connection_port() const { return m_connection_port; }
 
   /**
+   * The peer_id used in the handshakes and tracker requests.
+   */
+  [[nodiscard]] auto peer_id() const { return m_peer_id; }
+
+  /**
    * Find the file at a specific position in the torrent.
    * @param pos The offset into the torrent file
    * @return A tuple with (FileInfo, int64_t offset_in_file, int64_t tail)
@@ -308,6 +313,7 @@ class Torrent {
   ListeningPort m_listening_port{20001};
   ConnectionPort m_connection_port{20000};
   std::vector<std::shared_ptr<Peer>> m_peers{};
+  std::string m_peer_id{};
 
   // Piece housekeeping
   mutable std::mutex m_mutex{};


### PR DESCRIPTION
Should not use hardcoded peer_id. Now generate a random 20 char string. The spec
say that it could be any bytes, but remote clients did not seem to like it so
settled on a simple alphanumeric string.