### PR TITLE
Fix multiple use of FileWriter

### DIFF
--- a/src/file_writer.cpp
+++ b/src/file_writer.cpp
@@ -23,6 +23,7 @@ void FileWriter::add(Torrent* torrent, const shared_ptr<Piece>& piece) {
 
 void FileWriter::run() {
   logger()->info("FileWriter starting");
+  m_stop = false;
   while (!m_stop) {
     write_next_piece();
   }

--- a/src/file_writer.hpp
+++ b/src/file_writer.hpp
@@ -120,6 +120,7 @@ class FileWriterThread {
     m_logger->debug("FileWriter stopping");
     m_file_writer.stop();
     m_file_writer_thread.join();
+    m_logger->debug("FileWriter stopped");
   }
 
  private:


### PR DESCRIPTION
If the FileWriter is used more than once we must make sure to mark it as
unstopped when calling run() or the second run will just die immediately.