### PR TITLE
Integration_tests_fixes

### DIFF
--- a/src/file_writer.cpp
+++ b/src/file_writer.cpp
@@ -213,7 +213,19 @@ class MultiTorrentDestination : public TorrentDestination {
     }
   }
 
-  void torrentComplete() override { fs::remove(torrent()->tmpfile()); }
+  void torrentComplete() override {
+    // Depending on if we resumed or not we might or might not
+    // have the tmp file suffix. Thus try to only delete the suffixed one.
+    const auto tmpfile = [&] {
+      if (torrent()->tmpfile().native().ends_with(
+              Torrent::tmpfileExtension())) {
+        return torrent()->tmpfile();
+      }
+      return torrent()->tmpfile() += Torrent::tmpfileExtension();
+    }();
+
+    fs::remove(tmpfile);
+  }
 };
 
 shared_ptr<TorrentDestination> TorrentDestination::create(

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -93,7 +93,9 @@ bytes Piece::get_block(uint32_t offset,
   }
   // Is it on disk?
   m_logger->debug("Returning block {} in piece {} from disk", block_id, m_id);
-  auto file_offset = m_piece_size * m_id + offset;
+  // Important to use the piece_length from the torrent, since the last
+  // piece is often shorter and can't thus be used to get the offset.
+  const auto file_offset = torrent.piece_length() * m_id + offset;
   return FileWriter::getInstance().read_block(file_offset, length, torrent);
 }
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -85,7 +85,7 @@ Torrent::Torrent(const filesystem::path& file, std::filesystem::path data_dir)
   const auto& info = root_dict.at("info")->to<TypedElement<BeDict>>()->val();
 
   m_name = m_data_dir / info.at("name")->to<TypedElement<string>>()->val();
-  m_tmpfile = m_name + ".zit_downloading";
+  m_tmpfile = m_name + Torrent::tmpfileExtension();
   m_logger->debug("Using tmpfile {} for {}", m_tmpfile, file);
   auto pieces = info.at("pieces")->to<TypedElement<string>>()->val();
   if (pieces.size() % 20) {
@@ -177,6 +177,13 @@ void Torrent::verify_existing_file() {
     m_tmpfile = m_name;
     full_file = true;
   }
+
+  if (!is_single_file() && filesystem::exists(m_name)) {
+    // We have either started or finished this torrent
+    // Ensure that we verify the content.
+    m_tmpfile = m_name;
+  }
+
   if (filesystem::exists(m_tmpfile)) {
     std::atomic_uint32_t num_pieces = 0;
     std::mutex mutex;

--- a/src/torrent.hpp
+++ b/src/torrent.hpp
@@ -161,6 +161,11 @@ class Torrent {
   [[nodiscard]] auto tmpfile() const { return m_tmpfile; }
 
   /**
+   * The suffix of a file used during transfer (before completion)
+   */
+  [[nodiscard]] static auto tmpfileExtension() { return ".zit_downloading"; }
+
+  /**
    * List of connected peers
    */
   [[nodiscard]] auto& peers() { return m_peers; }

--- a/tests/test_integrate.cpp
+++ b/tests/test_integrate.cpp
@@ -280,7 +280,8 @@ TEST_P(IntegrateF, DISABLED_download_part) {
 
   // Copy ready file to download_dir and modify a piece
   // such that it will be retransfered.
-  const auto fn = download_dir / "1MiB.dat.zit_downloading";
+  const auto fn = download_dir / "1MiB.dat" +=
+      zit::Torrent::tmpfileExtension();
   fs::copy_file(data_dir / "1MiB.dat", fn);
   auto content = zit::read_file(fn);
   constexpr auto byte_to_change = 300'000;
@@ -313,7 +314,8 @@ TEST_F(Integrate, DISABLED_download_multi_part) {
   // Copy ready files to download_dir and mofify one
   // such that it will be retranfered.
   fs::copy(data_dir / "multi", download_dir / "multi");
-  zit::write_file(download_dir / "multi.zit_downloading", "");
+  zit::write_file(download_dir / "multi" += zit::Torrent::tmpfileExtension(),
+                  "");
   const auto fn = download_dir / "multi" / "b";
   auto content = zit::read_file(fn);
   constexpr auto byte_to_change = 500;


### PR DESCRIPTION
An earlier change made sure not to add the inactive peers, but we should also
avoid adding any peers we already have connected to.