### PR TITLE
Support multi-trackers #34

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(zitest
 target_link_libraries(zitest
   asio::asio
   GTest::gtest
+  GTest::gmock
   OpenSSL::SSL
   spdlog::spdlog
   TBB::tbb


### PR DESCRIPTION
This use the "announce-list" in addition to "announce" following the multi tracker spec.

This also uses functional dependency injection to test by replacing Net::httpGet().