### PR TITLE
Update gtest due to compile issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if(UNIX)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(
       -Wno-restrict                       # gcc 12 gets problems with including spdlog
+      -Wno-error=stringop-overflow        # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88443
     )
   endif()
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "gtest",
-      "version": "1.12.1"
+      "version": "1.14.0"
     },
     {
       "name": "tbb",
@@ -28,5 +28,5 @@
       "version": "1.12.0"
     }
   ],
-  "builtin-baseline": "c95000e1b5bb62884de08d5e952993c8bced9db6"
+  "builtin-baseline": "820cf6afbd87244f1728d2dd7938a7ae38cf7ecf"
 }


### PR DESCRIPTION
Old gtest did not compile after updating msvc, latest one do though.